### PR TITLE
Remove a trailing comma in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,6 @@
 	},
 	"scripts": {
 		"format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
-		"lint": "phpcs --standard=phpcs.xml.dist",
+		"lint": "phpcs --standard=phpcs.xml.dist"
 	}
 }


### PR DESCRIPTION
Smallest PR ever 😬  Got an error message about this when running `composer install`:

```
  "./composer.json" does not contain valid JSON                     
  Parse error on line 45:                                           
  ...d=phpcs.xml.dist",	}}                                           
  ---------------------^                                            
  Expected: 'STRING' - It appears you have an extra trailing comma                                                                 
```