### PR TITLE
Add the navigation post and use it in the header

### DIFF
--- a/wp-movies-theme/functions.php
+++ b/wp-movies-theme/functions.php
@@ -9,3 +9,19 @@ function enqueue_editor_styles() {
 	wp_enqueue_style( 'editor-style', get_theme_file_uri( '/editor-style.css' ) );
 }
 add_action( 'enqueue_block_editor_assets', 'enqueue_editor_styles' );
+
+function create_header_navigation() {
+	$header_navigation = get_page_by_title( 'Header navigation', OBJECT, 'wp_navigation' );
+	if ( ! $header_navigation ) {
+		$header_navigation = array(
+			'import_id'    => 123456789, // A magic number that is also used in the header.html file.
+			'post_title'   => 'Header navigation',
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_navigation',
+			'post_name'    => 'header-navigation',
+			'post_content' => '<!-- wp:navigation-link {"label":"Movies","url":"/","title":"Movies","kind":"custom","isTopLevelLink":true} /--> <!-- wp:navigation-link {"label":"Actors","url":"/actors","title":"Actors","kind":"custom","isTopLevelLink":true} /-->',
+		);
+		wp_insert_post( $header_navigation );
+	}
+}
+add_action( 'wp_loaded', 'create_header_navigation' );

--- a/wp-movies-theme/parts/header.html
+++ b/wp-movies-theme/parts/header.html
@@ -5,7 +5,7 @@
 <!-- wp:group {"layout":{"type":"flex","justifyContent":"left","verticalAlignment":"bottom","flexWrap":"wrap"}} -->
 <div class="wp-block-group"><!-- wp:wpmovies/favorites-number /-->
 
-<!-- wp:navigation {"ref":3790771,"layout":{"type":"flex","justifyContent":"left"}} /--></div>
+<!-- wp:navigation {"ref":123456789,"layout":{"type":"flex","justifyContent":"left"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
This adds a post of type `wp_navigation` on the initial load. This post is used in the Navigation block in the header of the theme to add a list of links to `Movies` and `Actors` pages.