### PR TITLE
Create a `Movie Search` block

### DIFF
--- a/src/blocks/movie-search/block.json
+++ b/src/blocks/movie-search/block.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wpmovies/movie-search",
+	"version": "0.1.0",
+	"title": "WP Movies - Search",
+	"category": "text",
+	"icon": "search",
+	"description": "",
+	"textdomain": "wpmovies",
+	"editorScript": "file:./index.js",
+	"render": "file:./render.php",
+	"editorStyle": "file:./style.css",
+	"style": "file:./style-index.css"
+}

--- a/src/blocks/movie-search/edit.js
+++ b/src/blocks/movie-search/edit.js
@@ -1,0 +1,28 @@
+import '@wordpress/block-editor';
+import { useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+const Edit = () => {
+	return (
+		<>
+			<div {...useBlockProps()}>
+				<input
+					type="text"
+					placeholder={__('Search movies', 'wp-movies')}
+				/>
+				<button type="submit" aria-label="Search">
+					<svg
+						class="search-icon"
+						viewBox="0 0 24 24"
+						width="24"
+						height="24"
+					>
+						<path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>
+					</svg>
+				</button>
+			</div>
+		</>
+	);
+};
+
+export default Edit;

--- a/src/blocks/movie-search/index.js
+++ b/src/blocks/movie-search/index.js
@@ -1,0 +1,8 @@
+import { registerBlockType } from '@wordpress/blocks';
+import Edit from './edit';
+import './style.scss';
+
+registerBlockType('wpmovies/movie-search', {
+	edit: Edit,
+	save: () => null,
+});

--- a/src/blocks/movie-search/render.php
+++ b/src/blocks/movie-search/render.php
@@ -1,0 +1,30 @@
+<?php
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class' => 'movie-search',
+	)
+);
+?>
+
+<div <?php echo $wrapper_attributes; ?> >
+	<input
+	  type="search" 
+	  name="s" 
+		inputmode="search"
+	  placeholder="Search for a movie..." 
+	  required=""
+		wp-bind:value="state.search.value"
+		wp-on:input="actions.search.update"
+		wp-on:focusout="actions.search.focusout"
+	>
+	<!-- <button 
+	  type="submit" 
+	  aria-label="Search"
+		class="search-button"
+	>
+	  <svg class="search-icon" viewBox="0 0 24 24" width="24" height="24">
+		<path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>
+	  </svg>
+	</button> -->
+</div>

--- a/src/blocks/movie-search/style.scss
+++ b/src/blocks/movie-search/style.scss
@@ -1,0 +1,16 @@
+.wp-block-wpmovies-movie-search > input {
+  background-color: #252525;
+  width: 10rem;
+  height: 40px;
+  border: none;
+  color: rgb(215, 215, 215);
+  position: relative;
+  padding: 7px;
+}
+
+.wp-block-wpmovies-movie-search > input:focus-visible {
+  background-color: #2e2e2e;
+  border:none;
+  padding: 7px;
+  outline: none;
+}

--- a/src/blocks/movie-search/view.js
+++ b/src/blocks/movie-search/view.js
@@ -1,0 +1,53 @@
+import { wpx } from '../../../lib/runtime/wpx.js';
+import { navigate } from '../../../lib/runtime/router.js';
+
+const debounce = (func, delay) => {
+	let timerId;
+	return (...args) => {
+		clearTimeout(timerId);
+		timerId = setTimeout(() => func(...args), delay);
+	};
+};
+
+const updateURL = async (value) => {
+	const url = new URL(window.location);
+	url.searchParams.set('post_type', 'movies');
+	url.searchParams.set('orderby', 'name');
+	url.searchParams.set('order', 'asc');
+	url.searchParams.set('s', value);
+	await navigate(`/${url.search}${url.hash}`);
+};
+
+wpx({
+	state: {
+		search: {
+			value: '',
+		},
+	},
+	actions: {
+		search: {
+			update: async ({ state, event }) => {
+				// Update the state.
+				const { value } = event.target;
+				if (value === state.search.value) return;
+				state.search.value = value;
+
+				// Update the URL.
+				await updateURL(value);
+
+				// Focus the input.
+				document
+					.querySelector('.wp-block-wpmovies-movie-search > input')
+					.focus();
+			},
+			focusout: ({ state, event }) => {
+				if (
+					event.target.value === '' &&
+					window.location.search !== ''
+				) {
+					navigate('/');
+				}
+			},
+		},
+	},
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = [
 			'query-loop-variations': './lib/query-loop-variations',
 			'blocks/favorites-number/view':
 				'./src/blocks/favorites-number/view',
+			'blocks/movie-search/view': './src/blocks/movie-search/view',
 		},
 		output: {
 			filename: '[name].js',

--- a/wp-movies-theme/parts/header.html
+++ b/wp-movies-theme/parts/header.html
@@ -2,6 +2,8 @@
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"30px","top":"0","right":"0","left":"0"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide" style="padding-top:0;padding-right:0;padding-bottom:30px;padding-left:0"><!-- wp:site-title /-->
 
+<!-- wp:wpmovies/movie-search /-->
+
 <!-- wp:group {"layout":{"type":"flex","justifyContent":"left","verticalAlignment":"bottom","flexWrap":"wrap"}} -->
 <div class="wp-block-group"><!-- wp:wpmovies/favorites-number /-->
 

--- a/wp-movies-theme/style.css
+++ b/wp-movies-theme/style.css
@@ -24,3 +24,7 @@ Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, feature
   left: 15px;
   margin-top: 0.5rem;
 }
+
+.search-result-row:hover {
+  background-color: #252525;
+}

--- a/wp-movies-theme/templates/index.html
+++ b/wp-movies-theme/templates/index.html
@@ -3,14 +3,10 @@
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"},"blockGap":"0","margin":{"top":"0","bottom":"0"}}},"layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:query {"queryId":3,"query":{"perPage":"8","pages":0,"offset":0,"order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[],"postType":"movies"},"tagName":"main","displayLayout":{"type":"flex","columns":4},"namespace":"wpmovies/movies-query-loop","align":"wide","layout":{"type":"constrained","contentSize":"1200px"}} -->
 <main class="wp-block-query alignwide"><!-- wp:post-template -->
-<!-- wp:group {"className":"movie-image-container","layout":{"type":"constrained"}} -->
-<div class="wp-block-group movie-image-container"><!-- wp:post-featured-image {"isLink":true,"dimRatio":40,"customGradient":"linear-gradient(148deg,rgb(0,0,0) 14%,rgba(255,255,255,0) 59%)","style":{"color":[]}} /-->
+<!-- wp:group {"style":{"spacing":{"blockGap":"0","padding":{"right":"0","left":"0","bottom":"var:preset|spacing|30"}}},"className":"movie-image-container","layout":{"type":"constrained"}} -->
+<div class="wp-block-group movie-image-container" style="padding-right:0;padding-bottom:var(--wp--preset--spacing--30);padding-left:0"><!-- wp:post-featured-image {"isLink":true,"dimRatio":40,"customGradient":"linear-gradient(148deg,rgb(0,0,0) 14%,rgba(255,255,255,0) 59%)","style":{"color":[]}} /-->
 
 <!-- wp:wpmovies/post-favorite /--></div>
-<!-- /wp:group -->
-
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"300"},"spacing":{"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|70"}}},"fontSize":"large"} /--></div>
 <!-- /wp:group -->
 <!-- /wp:post-template -->
 

--- a/wp-movies-theme/templates/search.html
+++ b/wp-movies-theme/templates/search.html
@@ -1,0 +1,13 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:query {"queryId":25,"query":{"perPage":"5","pages":0,"offset":0,"postType":"movies","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":true,"parents":[]},"displayLayout":{"type":"list","columns":3},"layout":{"type":"default"}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"},"blockGap":"var:preset|spacing|50"}},"className":"search-result-row","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group search-result-row" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:post-featured-image {"isLink":true,"width":"65px"} /-->
+
+<!-- wp:post-title {"level":3,"isLink":true} /--></div>
+<!-- /wp:group -->
+<!-- /wp:post-template --></div>
+<!-- /wp:query --></div>
+<!-- /wp:group -->

--- a/wpmovies.php
+++ b/wpmovies.php
@@ -42,6 +42,7 @@ add_action(
 		register_block_type( __DIR__ . '/build/blocks/favorites-number' );
 		register_block_type( __DIR__ . '/build/blocks/movie-data' );
 		register_block_type( __DIR__ . '/build/blocks/movie-reviews' );
+		register_block_type( __DIR__ . '/build/blocks/movie-search' );
 	}
 );
 
@@ -52,6 +53,17 @@ add_filter(
 		wp_enqueue_script(
 			'wpmovies/favorites-number',
 			plugin_dir_url( __FILE__ ) . 'build/blocks/favorites-number/view.js'
+		);
+		return $content;
+	}
+);
+
+add_filter(
+	'render_block_wpmovies/movie-search',
+	function ( $content ) {
+		wp_enqueue_script(
+			'wpmovies/movie-search',
+			plugin_dir_url( __FILE__ ) . 'build/blocks/movie-search/view.js'
 		);
 		return $content;
 	}


### PR DESCRIPTION
Adds a Movie Search block that allows users to instantly search for available movies. 

It uses the Query Loop block and the server-side rendered markup from the `?post_type=movies&orderby=name&order=asc&s=<search-term>` page.