### PR TITLE
Move the state, actions & selectors used by a block to that blocks' `view.js` file

### DIFF
--- a/src/blocks/favorites-number/view.js
+++ b/src/blocks/favorites-number/view.js
@@ -9,25 +9,10 @@ wpx({
 	},
 	selectors: {
 		favorites: {
-			isPostIncluded: ({ state, context: { post } }) =>
-				`https://s.w.org/images/core/emoji/14.0.0/svg/${
-					state.favorites.posts.includes(post.id) ? '2764' : '1f90d'
-				}.svg`,
 			isFavoritePostsEmpty: ({ state }) =>
 				`https://s.w.org/images/core/emoji/14.0.0/svg/${
 					state.favorites.posts.length !== 0 ? '2764' : '1f90d'
 				}.svg`,
-		},
-	},
-	actions: {
-		favorites: {
-			togglePost: ({ state, context }) => {
-				const index = state.favorites.posts.findIndex(
-					(post) => post === context.post.id
-				);
-				if (index === -1) state.favorites.posts.push(context.post.id);
-				else state.favorites.posts.splice(index, 1);
-			},
 		},
 	},
 });

--- a/src/blocks/favorites-number/view.js
+++ b/src/blocks/favorites-number/view.js
@@ -3,7 +3,8 @@ import { wpx } from '../../../lib/runtime/wpx.js';
 wpx({
 	state: {
 		favorites: {
-			posts: [],
+			// state.favorites.posts is defined in `favorites-number/view.js`.
+			// The state is shared between all blocks!
 			count: ({ state }) => state.favorites.posts.length,
 		},
 	},

--- a/src/blocks/post-favorite/view.js
+++ b/src/blocks/post-favorite/view.js
@@ -1,0 +1,28 @@
+import { wpx } from '../../../lib/runtime/wpx.js';
+
+wpx({
+	state: {
+		favorites: {
+			posts: [],
+		},
+	},
+	selectors: {
+		favorites: {
+			isPostIncluded: ({ state, context: { post } }) =>
+				`https://s.w.org/images/core/emoji/14.0.0/svg/${
+					state.favorites.posts.includes(post.id) ? '2764' : '1f90d'
+				}.svg`,
+		},
+	},
+	actions: {
+		favorites: {
+			togglePost: ({ state, context }) => {
+				const index = state.favorites.posts.findIndex(
+					(post) => post === context.post.id
+				);
+				if (index === -1) state.favorites.posts.push(context.post.id);
+				else state.favorites.posts.splice(index, 1);
+			},
+		},
+	},
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = [
 			'query-loop-variations': './lib/query-loop-variations',
 			'blocks/favorites-number/view':
 				'./src/blocks/favorites-number/view',
+			'blocks/post-favorite/view': './src/blocks/post-favorite/view',
 			'blocks/movie-search/view': './src/blocks/movie-search/view',
 		},
 		output: {

--- a/wpmovies.php
+++ b/wpmovies.php
@@ -68,3 +68,14 @@ add_filter(
 		return $content;
 	}
 );
+
+add_filter(
+	'render_block_wpmovies/post-favorite',
+	function ( $content ) {
+		wp_enqueue_script(
+			'wpmovies/post-favorite',
+			plugin_dir_url( __FILE__ ) . 'build/blocks/post-favorite/view.js'
+		);
+		return $content;
+	}
+);


### PR DESCRIPTION
⚠️ **Stacked PR (note the PR base)**

The `view.js` file for the `favorites-number` block contains the actions and state that are also used by the `post-favorites` block.

I've added a new `view.js` file for the `post-favorites` block that includes the references to the state and actions used in that block's `render.php`.

This way, the actions, state and selectors are defined within the same block and there's a better separation of concerns.