### PR TITLE
Replace deprecated `get_page_by_title()` with `WP_Query()`

### DIFF
--- a/wp-movies-theme/functions.php
+++ b/wp-movies-theme/functions.php
@@ -11,17 +11,27 @@ function enqueue_editor_styles() {
 add_action( 'enqueue_block_editor_assets', 'enqueue_editor_styles' );
 
 function create_header_navigation() {
-	$header_navigation = get_page_by_title( 'Header navigation', OBJECT, 'wp_navigation' );
-	if ( ! $header_navigation ) {
-		$header_navigation = array(
-			'import_id'    => 123456789, // A magic number that is also used in the header.html file.
-			'post_title'   => 'Header navigation',
-			'post_status'  => 'publish',
-			'post_type'    => 'wp_navigation',
-			'post_name'    => 'header-navigation',
-			'post_content' => '<!-- wp:navigation-link {"label":"Movies","url":"/","title":"Movies","kind":"custom","isTopLevelLink":true} /--> <!-- wp:navigation-link {"label":"Actors","url":"/actors","title":"Actors","kind":"custom","isTopLevelLink":true} /-->',
-		);
-		wp_insert_post( $header_navigation );
+
+	$query = new WP_Query(
+		array(
+			'title'          => 'Header navigation',
+			'post_type'      => 'wp_navigation',
+			'posts_per_page' => 1,
+		)
+	);
+	$pages = $query->posts;
+	if ( ! empty( $pages ) ) {
+		return null;
 	}
+	$header_navigation = array(
+		'import_id'    => 123456789, // A magic number that is also used in the header.html file.
+		'post_title'   => 'Header navigation',
+		'post_status'  => 'publish',
+		'post_type'    => 'wp_navigation',
+		'post_name'    => 'header-navigation',
+		'post_content' => '<!-- wp:navigation-link {"label":"Movies","url":"/","title":"Movies","kind":"custom","isTopLevelLink":true} /--> <!-- wp:navigation-link {"label":"Actors","url":"/actors","title":"Actors","kind":"custom","isTopLevelLink":true} /-->',
+	);
+	wp_insert_post( $header_navigation );
+
 }
 add_action( 'wp_loaded', 'create_header_navigation' );


### PR DESCRIPTION
The title says it all. `get_page_by_title()` is [deprecated](https://core.trac.wordpress.org/ticket/57041) in WordPress 6.2.