### PR TITLE
Add more data to movie pages

### DIFF
--- a/src/blocks/movie-background/block.json
+++ b/src/blocks/movie-background/block.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wpmovies/movie-background",
+	"version": "0.1.0",
+	"title": "WP Movies - Movie Background",
+	"category": "text",
+	"icon": "camera",
+	"description": "",
+	"textdomain": "wpmovies",
+	"editorScript": "file:./index.js",
+	"render": "file:./render.php",
+	"style": "file:./style-index.css"
+}

--- a/src/blocks/movie-background/edit.js
+++ b/src/blocks/movie-background/edit.js
@@ -1,0 +1,12 @@
+import '@wordpress/block-editor';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+const Edit = () => {
+	return (
+		<div {...useBlockProps()}>
+			<InnerBlocks />
+		</div>
+	);
+};
+
+export default Edit;

--- a/src/blocks/movie-background/index.js
+++ b/src/blocks/movie-background/index.js
@@ -1,0 +1,15 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
+import Edit from './edit';
+import './style.css';
+
+registerBlockType('wpmovies/movie-background', {
+	edit: Edit,
+	save: () => {
+		return (
+			<div>
+				<InnerBlocks.Content />
+			</div>
+		);
+	},
+});

--- a/src/blocks/movie-background/render.php
+++ b/src/blocks/movie-background/render.php
@@ -1,0 +1,21 @@
+<?php
+$post = get_post();
+$background_image_id = get_post_meta($post->ID, '_wpmovies_backdrop_img_id', true);
+$background_image_url = wp_get_attachment_image_url($background_image_id, '');
+$wrapper_attributes = get_block_wrapper_attributes(
+   [
+      'class' => 'wpmovies-movie-background-wrapper',
+      'style' => 'background-image: url(' . $background_image_url . ');'
+   ]
+);
+$inner_blocks_html = '';
+foreach ($block->inner_blocks as $inner_block) {
+   $inner_blocks_html .= $inner_block->render();
+}
+?>
+
+<div <?php echo $wrapper_attributes; ?>>
+   <div class="wpmovies-movie-background-inner-wrapper">
+      <?= $inner_blocks_html ?>
+   </div>
+</div>

--- a/src/blocks/movie-background/style.css
+++ b/src/blocks/movie-background/style.css
@@ -1,0 +1,15 @@
+.wpmovies-movie-background-wrapper {
+	background-position: left calc((50vw - 170px) - 340px) top;
+	background-size: cover;
+	background-repeat: no-repeat;
+}
+
+.wpmovies-movie-background-inner-wrapper {
+	padding: 40px;
+	background-image: linear-gradient(
+		to right,
+		#404040 calc((50vw - 170px) - 340px),
+		#404040d9 30%,
+		#404040d9 100%
+	);
+}

--- a/src/blocks/movie-data/block.json
+++ b/src/blocks/movie-data/block.json
@@ -10,25 +10,5 @@
 	"textdomain": "wpmovies",
 	"editorScript": "file:./index.js",
 	"render": "file:./render.php",
-	"supports": {
-		"color": {
-			"background": true,
-			"text": true,
-			"link": false
-		},
-		"typography": {
-			"fontSize": true,
-			"lineHeight": true,
-			"fontStyle": true,
-			"fontWeight": true,
-			"textTransform": true,
-			"textDecoration": true,
-			"letterSpacing": true
-		},
-		"html": false,
-		"spacing": {
-			"padding": true,
-			"margin": true
-		}
-	}
+	"style": "file:./style-index.css"
 }

--- a/src/blocks/movie-data/index.js
+++ b/src/blocks/movie-data/index.js
@@ -1,5 +1,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 import Edit from './edit';
+import './style.css';
 
 registerBlockType('wpmovies/movie-data', {
 	edit: Edit,

--- a/src/blocks/movie-data/render.php
+++ b/src/blocks/movie-data/render.php
@@ -2,8 +2,72 @@
 $post = get_post();
 $wrapper_attributes = get_block_wrapper_attributes();
 $release_date = get_post_meta($post->ID, '_wpmovies_release_date', true);
+$status = get_post_meta($post->ID, '_wpmovies_status', true);
+$language = get_post_meta($post->ID, '_wpmovies_language', true);
+$runtime_minutes = get_post_meta($post->ID, '_wpmovies_runtime', true);
+$runtime = $hours = intdiv($runtime_minutes, 60) . 'h ' . ($runtime_minutes % 60) . 'm';
+$homepage_url = get_post_meta($post->ID, '_wpmovies_homepage', true);
+if ($homepage_url == "") {
+   $homepage_html = "-";
+} else {
+   $homepage_html = '
+   <a target="_blank" href="' . $homepage_url . '">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+         <path fill="#ffffff" d="M6.188 8.719c.439-.439.926-.801 1.444-1.087 2.887-1.591 6.589-.745 8.445 2.069l-2.246 2.245c-.644-1.469-2.243-2.305-3.834-1.949-.599.134-1.168.433-1.633.898l-4.304 4.306c-1.307 1.307-1.307 3.433 0 4.74 1.307 1.307 3.433 1.307 4.74 0l1.327-1.327c1.207.479 2.501.67 3.779.575l-2.929 2.929c-2.511 2.511-6.582 2.511-9.093 0s-2.511-6.582 0-9.093l4.304-4.306zm6.836-6.836l-2.929 2.929c1.277-.096 2.572.096 3.779.574l1.326-1.326c1.307-1.307 3.433-1.307 4.74 0 1.307 1.307 1.307 3.433 0 4.74l-4.305 4.305c-1.311 1.311-3.44 1.3-4.74 0-.303-.303-.564-.68-.727-1.051l-2.246 2.245c.236.358.481.667.796.982.812.812 1.846 1.417 3.036 1.704 1.542.371 3.194.166 4.613-.617.518-.286 1.005-.648 1.444-1.087l4.304-4.305c2.512-2.511 2.512-6.582.001-9.093-2.511-2.51-6.581-2.51-9.092 0z" />
+      </svg>
+   </a>
+';
+}
+$budget = intval(get_post_meta($post->ID, '_wpmovies_budget', true));
+if ($budget == 0) {
+   $budget = "-";
+} else {
+   $budget = '$' . strval(number_format($budget));
+}
+$revenue = intval(get_post_meta($post->ID, '_wpmovies_revenue', true));
+if ($revenue == 0) {
+   $revenue = "-";
+} else {
+   $revenue = '$' . strval(number_format($revenue));
+}
+
+$categories_html = '';
+if (count(wp_get_post_categories($post->ID)) == 0) {
+   $categories_html = '-';
+} else {
+   foreach (wp_get_post_categories($post->ID) as $category_id) {
+      $categories_html .= '<a wp-link="{ \'prefetch\': true }" href="' . get_category_link($category_id) . '" class="wpmovies-category-link">' . get_cat_name($category_id) . '</a>';
+   }
+}
+
+if (!function_exists('wpmovies_get_item_html')) {
+   function wpmovies_get_item_html($metafield, $key)
+   {
+      if ($metafield == "") {
+         return;
+      }
+      return '
+      <li class="wpmovies-data-list-item">
+         <div class="wpmovies-data-list-key">' . $key . '</div>
+         <div class="wpmovies-data-list-value">' . $metafield . '</div>
+      </li>
+   ';
+   }
+}
 ?>
 
 <div <?php echo $wrapper_attributes; ?>>
-   Released: <?= $release_date ?>
+   <ul class="wpmovies-data-list">
+      <?php echo wpmovies_get_item_html($release_date, "Released") ?>
+      <?php echo wpmovies_get_item_html($status, "Status") ?>
+      <?php echo wpmovies_get_item_html($runtime, "Runtime") ?>
+      <li class="wpmovies-data-list-item wpmovies-categories">
+         <div class="wpmovies-data-list-key">Categories</div>
+         <div class="wpmovies-data-list-value"><?php echo $categories_html ?></div>
+      </li>
+      <?php echo wpmovies_get_item_html($language, "Language") ?>
+      <?php echo wpmovies_get_item_html($budget, "Budget") ?>
+      <?php echo wpmovies_get_item_html($revenue, "Revenue") ?>
+      <?php echo wpmovies_get_item_html($homepage_html, "Homepage") ?>
+   </ul>
 </div>

--- a/src/blocks/movie-data/style.css
+++ b/src/blocks/movie-data/style.css
@@ -1,0 +1,28 @@
+.wpmovies-data-list {
+	list-style: none;
+	padding: 0px;
+}
+
+.wpmovies-data-list li {
+	display: flex;
+	padding: 0.2rem 0;
+}
+
+.wpmovies-data-list-key {
+	flex: 1;
+	max-width: 90px;
+	margin-right: 1.5rem;
+}
+
+.wpmovies-data-list-value {
+	flex: 2;
+}
+
+.wpmovies-category-link {
+	text-decoration: none;
+	background-color: #081c22;
+	opacity: 0.8;
+	border-radius: 4px;
+	padding: 4px;
+	margin-right: 4px;
+}

--- a/src/blocks/movie-score/block.json
+++ b/src/blocks/movie-score/block.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wpmovies/movie-score",
+	"version": "0.1.0",
+	"title": "WP Movies - Movie Score",
+	"category": "text",
+	"icon": "marker",
+	"description": "",
+	"textdomain": "wpmovies",
+	"editorScript": "file:./index.js",
+	"render": "file:./render.php",
+	"style": "file:./style-index.css"
+}

--- a/src/blocks/movie-score/edit.js
+++ b/src/blocks/movie-score/edit.js
@@ -4,43 +4,40 @@ import './style.css';
 
 const Edit = () => {
 	return (
-		<>
-			<div
-				{...useBlockProps()}
-				class="wpmovies-score-wrap"
-				style={{
-					backgroundColor: '#21d07a55',
-				}}
-			>
-				<div class="wpmovies-score-circle">
+		<div
+			{...useBlockProps()}
+			class="wpmovies-score-wrap"
+			style={{
+				backgroundColor: '#21d07a55',
+			}}
+		>
+			<div class="wpmovies-score-circle">
+				<div
+					class="wpmovies-score-mask wpmovies-score-full"
+					style={{ transform: 'rotate(135deg)' }}
+				>
 					<div
-						class="wpmovies-score-mask wpmovies-score-full"
-						style={{ transform: 'rotate(135deg)' }}
-					>
-						<div
-							class="wpmovies-score-fill"
-							style={{
-								backgroundColor: '#21d07a',
-								transform: 'rotate(135deg)',
-							}}
-						></div>
-					</div>
-					<div class="wpmovies-score-mask wpmovies-score-half">
-						<div
-							class="wpmovies-score-fill"
-							style={{
-								backgroundColor: '#21d07a',
-								transform: 'rotate(135deg)',
-							}}
-						></div>
-					</div>
-					<div class="wpmovies-score-inside-circle">
-						<p>75%</p>
-					</div>
+						class="wpmovies-score-fill"
+						style={{
+							backgroundColor: '#21d07a',
+							transform: 'rotate(135deg)',
+						}}
+					></div>
+				</div>
+				<div class="wpmovies-score-mask wpmovies-score-half">
+					<div
+						class="wpmovies-score-fill"
+						style={{
+							backgroundColor: '#21d07a',
+							transform: 'rotate(135deg)',
+						}}
+					></div>
+				</div>
+				<div class="wpmovies-score-inside-circle">
+					<p>75%</p>
 				</div>
 			</div>
-			<p>1000 Reviews</p>
-		</>
+		</div>
 	);
 };
 

--- a/src/blocks/movie-score/edit.js
+++ b/src/blocks/movie-score/edit.js
@@ -1,0 +1,9 @@
+import '@wordpress/block-editor';
+import { useBlockProps } from '@wordpress/block-editor';
+import './style.css';
+
+const Edit = () => {
+	return <div {...useBlockProps()}>Movie Score</div>;
+};
+
+export default Edit;

--- a/src/blocks/movie-score/edit.js
+++ b/src/blocks/movie-score/edit.js
@@ -3,7 +3,42 @@ import { useBlockProps } from '@wordpress/block-editor';
 import './style.css';
 
 const Edit = () => {
-	return <div {...useBlockProps()}>Movie Score</div>;
+	return (
+		<div
+			{...useBlockProps()}
+			class="wpmovies-score-wrap"
+			style={{
+				backgroundColor: '#21d07a55',
+			}}
+		>
+			<div class="wpmovies-score-circle">
+				<div
+					class="wpmovies-score-mask wpmovies-score-full"
+					style={{ transform: 'rotate(135deg)' }}
+				>
+					<div
+						class="wpmovies-score-fill"
+						style={{
+							backgroundColor: '#21d07a',
+							transform: 'rotate(135deg)',
+						}}
+					></div>
+				</div>
+				<div class="wpmovies-score-mask wpmovies-score-half">
+					<div
+						class="wpmovies-score-fill"
+						style={{
+							backgroundColor: '#21d07a',
+							transform: 'rotate(135deg)',
+						}}
+					></div>
+				</div>
+				<div class="wpmovies-score-inside-circle">
+					<p>75%</p>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default Edit;

--- a/src/blocks/movie-score/edit.js
+++ b/src/blocks/movie-score/edit.js
@@ -4,40 +4,43 @@ import './style.css';
 
 const Edit = () => {
 	return (
-		<div
-			{...useBlockProps()}
-			class="wpmovies-score-wrap"
-			style={{
-				backgroundColor: '#21d07a55',
-			}}
-		>
-			<div class="wpmovies-score-circle">
-				<div
-					class="wpmovies-score-mask wpmovies-score-full"
-					style={{ transform: 'rotate(135deg)' }}
-				>
+		<>
+			<div
+				{...useBlockProps()}
+				class="wpmovies-score-wrap"
+				style={{
+					backgroundColor: '#21d07a55',
+				}}
+			>
+				<div class="wpmovies-score-circle">
 					<div
-						class="wpmovies-score-fill"
-						style={{
-							backgroundColor: '#21d07a',
-							transform: 'rotate(135deg)',
-						}}
-					></div>
-				</div>
-				<div class="wpmovies-score-mask wpmovies-score-half">
-					<div
-						class="wpmovies-score-fill"
-						style={{
-							backgroundColor: '#21d07a',
-							transform: 'rotate(135deg)',
-						}}
-					></div>
-				</div>
-				<div class="wpmovies-score-inside-circle">
-					<p>75%</p>
+						class="wpmovies-score-mask wpmovies-score-full"
+						style={{ transform: 'rotate(135deg)' }}
+					>
+						<div
+							class="wpmovies-score-fill"
+							style={{
+								backgroundColor: '#21d07a',
+								transform: 'rotate(135deg)',
+							}}
+						></div>
+					</div>
+					<div class="wpmovies-score-mask wpmovies-score-half">
+						<div
+							class="wpmovies-score-fill"
+							style={{
+								backgroundColor: '#21d07a',
+								transform: 'rotate(135deg)',
+							}}
+						></div>
+					</div>
+					<div class="wpmovies-score-inside-circle">
+						<p>75%</p>
+					</div>
 				</div>
 			</div>
-		</div>
+			<p>1000 Reviews</p>
+		</>
 	);
 };
 

--- a/src/blocks/movie-score/index.js
+++ b/src/blocks/movie-score/index.js
@@ -1,0 +1,7 @@
+import { registerBlockType } from '@wordpress/blocks';
+import Edit from './edit';
+
+registerBlockType('wpmovies/movie-score', {
+	edit: Edit,
+	save: () => null,
+});

--- a/src/blocks/movie-score/render.php
+++ b/src/blocks/movie-score/render.php
@@ -1,0 +1,26 @@
+<?php
+$post = get_post();
+$wrapper_attributes = get_block_wrapper_attributes();
+$score = get_post_meta($post->ID, '_wpmovies_vote_average', true);
+$score_color = '#21d07a'; // Green
+if ($score < 7 && $score >= 3) {
+   $score_color = '#fad900'; // Yellow
+} elseif ($score < 3) {
+   $score_color = '#de1600'; // Red
+};
+$degrees_css = $score * 180 / 10;
+?>
+
+<div class="wpmovies-score-wrap" <?php echo 'style="background-color: ' . $score_color . '55"' ?>>
+   <div class="wpmovies-score-circle">
+      <div class="wpmovies-score-mask wpmovies-score-full" <?php echo 'style="transform: rotate(' . $degrees_css . 'deg)"' ?>>
+         <div class="wpmovies-score-fill" <?php echo 'style="background-color: ' . $score_color . ';transform: rotate(' . $degrees_css . 'deg)"' ?>></div>
+      </div>
+      <div class="wpmovies-score-mask wpmovies-score-half">
+         <div class="wpmovies-score-fill" <?php echo 'style="background-color: ' . $score_color . ';transform: rotate(' . $degrees_css . 'deg)"' ?>></div>
+      </div>
+      <div class="wpmovies-score-inside-circle">
+         <p><?php echo round($score * 10) . "%" ?></p>
+      </div>
+   </div>
+</div>

--- a/src/blocks/movie-score/render.php
+++ b/src/blocks/movie-score/render.php
@@ -1,6 +1,7 @@
 <?php
 $post = get_post();
 $score = get_post_meta($post->ID, '_wpmovies_vote_average', true);
+$reviews_count = '' !== get_post_meta($post->ID, '_wpmovies_vote_count', true) ? get_post_meta($post->ID, '_wpmovies_vote_count', true) : '0';
 $score_color = '#21d07a'; // Green
 if ($score < 7 && $score >= 3) {
    $score_color = '#fad900'; // Yellow
@@ -30,3 +31,4 @@ $wrapper_attributes = get_block_wrapper_attributes(
       </div>
    </div>
 </div>
+<p><?= sprintf(__('%s Reviews', 'wp-movies'), $reviews_count)  ?></p>

--- a/src/blocks/movie-score/render.php
+++ b/src/blocks/movie-score/render.php
@@ -12,7 +12,7 @@ $degrees_css = $score * 180 / 10;
 $wrapper_attributes = get_block_wrapper_attributes(
    [
       'class' => 'wpmovies-score-wrap',
-      'style' => 'style="background-color: ' . $score_color . '55"',
+      'style' => 'background-color: ' . $score_color . '22',
    ]
 );
 ?>

--- a/src/blocks/movie-score/render.php
+++ b/src/blocks/movie-score/render.php
@@ -1,7 +1,6 @@
 <?php
 $post = get_post();
 $score = get_post_meta($post->ID, '_wpmovies_vote_average', true);
-$reviews_count = '' !== get_post_meta($post->ID, '_wpmovies_vote_count', true) ? get_post_meta($post->ID, '_wpmovies_vote_count', true) : '0';
 $score_color = '#21d07a'; // Green
 if ($score < 7 && $score >= 3) {
    $score_color = '#fad900'; // Yellow
@@ -31,4 +30,3 @@ $wrapper_attributes = get_block_wrapper_attributes(
       </div>
    </div>
 </div>
-<p><?= sprintf(__('%s Reviews', 'wp-movies'), $reviews_count)  ?></p>

--- a/src/blocks/movie-score/render.php
+++ b/src/blocks/movie-score/render.php
@@ -1,6 +1,5 @@
 <?php
 $post = get_post();
-$wrapper_attributes = get_block_wrapper_attributes();
 $score = get_post_meta($post->ID, '_wpmovies_vote_average', true);
 $score_color = '#21d07a'; // Green
 if ($score < 7 && $score >= 3) {
@@ -9,9 +8,16 @@ if ($score < 7 && $score >= 3) {
    $score_color = '#de1600'; // Red
 };
 $degrees_css = $score * 180 / 10;
+
+$wrapper_attributes = get_block_wrapper_attributes(
+   [
+      'class' => 'wpmovies-score-wrap',
+      'style' => 'style="background-color: ' . $score_color . '55"',
+   ]
+);
 ?>
 
-<div class="wpmovies-score-wrap" <?php echo 'style="background-color: ' . $score_color . '55"' ?>>
+<div <?php echo $wrapper_attributes; ?>>
    <div class="wpmovies-score-circle">
       <div class="wpmovies-score-mask wpmovies-score-full" <?php echo 'style="transform: rotate(' . $degrees_css . 'deg)"' ?>>
          <div class="wpmovies-score-fill" <?php echo 'style="background-color: ' . $score_color . ';transform: rotate(' . $degrees_css . 'deg)"' ?>></div>

--- a/src/blocks/movie-score/style.css
+++ b/src/blocks/movie-score/style.css
@@ -1,0 +1,38 @@
+.wpmovies-score-wrap {
+	position: relative;
+	margin: 60px auto;
+	width: 60px;
+	height: 60px;
+	border-radius: 50%;
+}
+
+.wpmovies-score-wrap .wpmovies-score-circle .wpmovies-score-mask,
+.wpmovies-score-wrap .wpmovies-score-circle .wpmovies-score-fill {
+	width: 60px;
+	height: 60px;
+	position: absolute;
+	border-radius: 50%;
+}
+
+.wpmovies-score-mask .wpmovies-score-fill {
+	clip: rect(0px, 30px, 60px, 0px);
+}
+
+.wpmovies-score-wrap .wpmovies-score-circle .wpmovies-score-mask {
+	clip: rect(0px, 60px, 60px, 30px);
+}
+
+.wpmovies-score-wrap .wpmovies-score-inside-circle {
+	position: absolute;
+	text-align: center;
+	width: 52px;
+	height: 52px;
+	border-radius: 50%;
+	background: #081c22;
+	z-index: 100;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	margin: auto;
+}

--- a/wp-movies-theme/templates/single-movies.html
+++ b/wp-movies-theme/templates/single-movies.html
@@ -7,6 +7,8 @@
 <!-- wp:wpmovies/post-favorite /--></div>
 <!-- /wp:group -->
 
+<!-- wp:wpmovies/movie-background -->
+<div>
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"width":"400px"} -->
 <div class="wp-block-column" style="flex-basis:400px"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} /--></div>
@@ -30,6 +32,8 @@
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
+</div>
+<!-- /wp:wpmovies/movie-background -->
 
 <!-- wp:heading -->
 <h2 class="wp-block-heading">Cast</h2>

--- a/wp-movies-theme/templates/single-movies.html
+++ b/wp-movies-theme/templates/single-movies.html
@@ -1,65 +1,63 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header","theme":"wp-movies-theme","tagName":"header"} /-->
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained","contentSize":"1200px"}} -->
-<main class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:post-title {"level":1,"fontSize":"large"} /-->
-
-<!-- wp:wpmovies/post-favorite /--></div>
-<!-- /wp:group -->
-
-<!-- wp:wpmovies/movie-background -->
-<div>
-<!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":"400px"} -->
-<div class="wp-block-column" style="flex-basis:400px"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} /--></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"verticalAlignment":"top","width":"66.66%","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0"}}} -->
-<div class="wp-block-column is-vertically-aligned-top" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;flex-basis:66.66%"><!-- wp:heading -->
-<h2 class="wp-block-heading">Storyline</h2>
-<!-- /wp:heading -->
-
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"></div>
-<!-- /wp:group -->
-
-<!-- wp:post-content {"fontSize":"medium"} /-->
-
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:wpmovies/movie-reviews /-->
-
-<!-- wp:wpmovies/movie-data {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","right":"0","bottom":"var:preset|spacing|50","left":"0"}}}} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
-</div>
-<!-- /wp:wpmovies/movie-background -->
-
-<!-- wp:heading -->
-<h2 class="wp-block-heading">Cast</h2>
-<!-- /wp:heading -->
-
-<!-- wp:query {"queryId":0,"query":{"perPage":4,"pages":0,"offset":0,"order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[],"postType":"actors"},"displayLayout":{"type":"flex","columns":4},"namespace":"wpmovies/cast-query-loop","align":"wide","layout":{"inherit":true,"justifyContent":"left"}} -->
-<div class="wp-block-query alignwide"><!-- wp:post-template -->
-<!-- wp:post-featured-image {"isLink":true} /-->
-
-<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"medium"} /-->
-<!-- /wp:post-template -->
-
-<!-- wp:query-pagination -->
-<!-- wp:query-pagination-previous /-->
-
-<!-- wp:query-pagination-numbers /-->
-
-<!-- wp:query-pagination-next /-->
-<!-- /wp:query-pagination -->
-
-<!-- wp:query-no-results -->
-<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-<p></p>
-<!-- /wp:paragraph -->
-<!-- /wp:query-no-results --></div>
-<!-- /wp:query --></main>
-<!-- /wp:group -->
-
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<main class="wp-block-group"><!-- wp:wpmovies/movie-background -->
+    <div><!-- wp:columns -->
+    <div class="wp-block-columns"><!-- wp:column {"width":"400px"} -->
+    <div class="wp-block-column" style="flex-basis:400px"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} /--></div>
+    <!-- /wp:column -->
+    
+    <!-- wp:column {"verticalAlignment":"top","width":"66.66%","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"0"}}} -->
+    <div class="wp-block-column is-vertically-aligned-top" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;flex-basis:66.66%"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+    <div class="wp-block-group"><!-- wp:post-title {"fontSize":"large"} /-->
+    
+    <!-- wp:wpmovies/post-favorite /--></div>
+    <!-- /wp:group -->
+    
+    <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","padding":{"top":"0","right":"0","bottom":"0","left":"0"},"margin":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+    <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--20);margin-bottom:var(--wp--preset--spacing--20);padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:wpmovies/movie-score /-->
+    
+    <!-- wp:paragraph -->
+    <p></p>
+    <!-- /wp:paragraph --></div>
+    <!-- /wp:group -->
+    
+    <!-- wp:heading {"level":3,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20","top":"0"}}}} -->
+    <h3 class="wp-block-heading" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--20)">Storyline</h3>
+    <!-- /wp:heading -->
+    
+    <!-- wp:post-content {"fontSize":"small"} /-->
+    
+    <!-- wp:wpmovies/movie-data /--></div>
+    <!-- /wp:column --></div>
+    <!-- /wp:columns --></div>
+    <!-- /wp:wpmovies/movie-background -->
+    
+    <!-- wp:heading -->
+    <h2 class="wp-block-heading">Cast</h2>
+    <!-- /wp:heading -->
+    
+    <!-- wp:query {"queryId":0,"query":{"perPage":4,"pages":0,"offset":0,"order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[],"postType":"actors"},"displayLayout":{"type":"flex","columns":4},"namespace":"wpmovies/cast-query-loop","align":"wide","layout":{"inherit":true,"justifyContent":"left","type":"constrained"}} -->
+    <div class="wp-block-query alignwide"><!-- wp:post-template -->
+    <!-- wp:post-featured-image {"isLink":true} /-->
+    
+    <!-- wp:post-title {"level":3,"isLink":true,"fontSize":"medium"} /-->
+    <!-- /wp:post-template -->
+    
+    <!-- wp:query-pagination -->
+    <!-- wp:query-pagination-previous /-->
+    
+    <!-- wp:query-pagination-numbers /-->
+    
+    <!-- wp:query-pagination-next /-->
+    <!-- /wp:query-pagination -->
+    
+    <!-- wp:query-no-results -->
+    <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+    <p></p>
+    <!-- /wp:paragraph -->
+    <!-- /wp:query-no-results --></div>
+    <!-- /wp:query --></main>
+    <!-- /wp:group -->
+    
+    <!-- wp:template-part {"slug":"footer","theme":"wp-movies-theme","tagName":"footer"} /-->

--- a/wpmovies.php
+++ b/wpmovies.php
@@ -45,6 +45,7 @@ add_action(
 		register_block_type( __DIR__ . '/build/blocks/movie-data' );
 		register_block_type( __DIR__ . '/build/blocks/movie-reviews' );
 		register_block_type( __DIR__ . '/build/blocks/movie-score' );
+		register_block_type( __DIR__ . '/build/blocks/movie-background' );
 	}
 );
 

--- a/wpmovies.php
+++ b/wpmovies.php
@@ -44,6 +44,7 @@ add_action(
 		register_block_type( __DIR__ . '/build/blocks/favorites-number' );
 		register_block_type( __DIR__ . '/build/blocks/movie-data' );
 		register_block_type( __DIR__ . '/build/blocks/movie-reviews' );
+		register_block_type( __DIR__ . '/build/blocks/movie-score' );
 	}
 );
 


### PR DESCRIPTION
This PR is based on `cron-db-update` branch because it includes more custom fields than the main branch. I'm using it to explore alternatives, I assume some parts won't be compatible with the `main` branch, as it is missing some data right now.

Based on [TMDB Templates](https://www.themoviedb.org/movie/19995-avatar), I started this Pull Request to add more data to our movie pages. I'm just exploring alternatives, and later we can decide which functionalities we should include or not.

This is an example of how it is going so far:

<img width="1496" alt="Screenshot 2023-02-16 at 09 08 05" src="https://user-images.githubusercontent.com/34552881/219307335-65c2277c-fdf1-43c8-8584-b70624c0f947.png">

What I've done:
- Add a background image with the one supplied by TMDB API.
- Substitute the "Stars Review" with the percentage circle. Depending on the score, the color will change.
- Add more movie data, not only the release data. This includes aspects like the runtime or even links to the categories of each movie.
- Update movie template.

What I still want to research:
- Modify the categories template to show the movies properly.
- Add a couple of interactive tabs to show Videos & Images.
- Add a Play Trailer button that ideally pops up a PiP Youtube video that can play while navigating.