### PR TITLE
Add `interactivity: true` to movie-trailer-button block

### DIFF
--- a/src/blocks/movie-trailer-button/block.json
+++ b/src/blocks/movie-trailer-button/block.json
@@ -8,6 +8,9 @@
 	"icon": "camera",
 	"description": "",
 	"textdomain": "wpmovies",
+	"supports": {
+		"interactivity": true
+	},
 	"editorScript": "file:./index.js",
 	"render": "file:./render.php",
 	"style": "file:./style-index.css"


### PR DESCRIPTION
I'm adding the `interactivity: true` to the `movie-trailer-button` blocks. Although it doesn't have a store, it is using some directives.

This solves the issue of the Trailer not playing when client-side navigations are disabled.