### PR TITLE
Add key attribute to each Query Loop item

### DIFF
--- a/lib/custom-query-block.php
+++ b/lib/custom-query-block.php
@@ -101,6 +101,28 @@ function wpmovies_build_query( $query ) {
 
 add_action( 'pre_render_block', 'wpmovies_update_demo_query', 10, 2 );
 
+/**
+ * Add a unique key attribute to each Query Loop item.
+ * 
+ * TODO: Replace with `data-wp-key` once this is fixed:
+ * https://github.com/WordPress/block-interactivity-experiments/issues/180
+ *
+ * @param $content The block content.
+ * @return $content The block content with the added key attributes.
+ */
+
+function wpmovies_add_key_to_query ( $content ) {
+	$p = new WP_HTML_Tag_Processor( $content );
+	while( $p->next_tag( array( 'tag_name' => 'li' ) ) ) {
+		$class = $p->get_attribute( 'class' );
+		if ( preg_match( '/\bpost-(\d+)\b/', $class, $matches ) ) {
+			$p->set_attribute( 'key', $matches[ 1 ] );
+		}
+	};
+	return ( string ) $p;
+}
+
+add_filter( 'render_block_core/query', 'wpmovies_add_key_to_query', 10, 1 );
 
 /**
  * Add the movie and the cast variations to the Query Loop block.


### PR DESCRIPTION
Adding a key makes Preact treat each item as a separate thing and fixes the weird UX of previous images staying on the screen when you paginate.

It should probably be done at the `<img>` level by default in Gutenberg, using the image database ID for the key. Here I did it in the `<li>` just for convenience.

Before (using Slow 3G):


https://user-images.githubusercontent.com/3305402/225347063-ca1cbfe5-04e8-4a4a-9499-040d75d5ceb1.mp4

---

After (using Slow 3G):


https://user-images.githubusercontent.com/3305402/225347224-528384eb-00fc-4bfb-a645-86c76bdee2c5.mp4


