### PR TITLE
Remove frontend emoji enqueue

### DIFF
--- a/wpmovies.php
+++ b/wpmovies.php
@@ -127,3 +127,9 @@ function movies_demo_plugin_deactivation() {
 	$timestamp = wp_next_scheduled( 'cron_wpmovies_add_movies' );
 	wp_unschedule_event( $timestamp, 'cron_wpmovies_add_movies' );
 }
+
+// Avoid sending any JavaScript not related to the Interactivity API.
+function dequeue_twemoji() {
+	remove_action( 'wp_head', 'print_emoji_detection_script', 7 ); // Emojis
+}
+add_action( 'wp_enqueue_scripts', 'dequeue_twemoji' );


### PR DESCRIPTION
To make things easier to analyze, the site should only enqueue the code of the Interactivity API. This PR just removes the emoji enqueues.

Before:

<img width="774" alt="Screenshot 2023-03-15 at 16 13 58" src="https://user-images.githubusercontent.com/3305402/225355344-c02b1212-5bb7-471f-8ec5-190dec552eab.png">

After:

<img width="774" alt="Screenshot 2023-03-15 at 16 14 15" src="https://user-images.githubusercontent.com/3305402/225355384-19cfc4cf-da51-4613-866f-3edb9c7dedfe.png">

---

We may need to add other removals for the live site at WP.com.