### PR TITLE
Populate search value from the URL query

### DIFF
--- a/src/blocks/movie-search/render.php
+++ b/src/blocks/movie-search/render.php
@@ -1,20 +1,30 @@
 <?php
-
 $wrapper_attributes = get_block_wrapper_attributes(
+	array( 'class' => 'movie-search' )
+);
+
+store(
 	array(
-		'class' => 'movie-search',
+		'state' => array(
+			'wpmovies' => array(
+				'searchValue' => '',
+			),
+		),
 	)
 );
 ?>
 
-<div <?php echo $wrapper_attributes; ?> >
-	<input
-	  type="search" 
-	  name="s" 
-		inputmode="search"
-	  placeholder="Search for a movie..." 
-	  required=""
-		wp-bind:value="state.search.value"
-		wp-on:input="actions.search.update"
+<div 
+	<?php echo $wrapper_attributes; ?>
+	wp-effect="effects.wpmovies.populateSearchValue"
+>
+	<input 
+		type="search" 
+		name="s" 
+		inputmode="search" 
+		placeholder="Search for a movie..." 
+		required="" 
+		wp-bind:value="state.wpmovies.searchValue" 
+		wp-on:input="actions.wpmovies.updateSearch"
 	>
 </div>

--- a/src/blocks/movie-search/view.js
+++ b/src/blocks/movie-search/view.js
@@ -37,4 +37,13 @@ wpx({
 			},
 		},
 	},
+	effects: {
+		wpmovies: {
+			populateSearchValue: ({ state }) => {
+				const url = new URL(window.location);
+				const value = url.searchParams.get('s');
+				state.wpmovies.searchValue = value;
+			},
+		},
+	},
 });


### PR DESCRIPTION
This just updates the value of the input search according to the value of the `?s=` query. Some notes:

- This could be done on the server (for SSR).
- This should use `wp-init`, but it doesn't seem like it exists yet.
- This doesn't convert `+` into spaces. I don't know if there are other edge cases like that.
- It's adding the `store()` because I created it on top of another branch that already contained it.