### PR TITLE
Fix: add aria-live region to query block so that the live updating results are announced to screen readers

### DIFF
--- a/wpmovies.php
+++ b/wpmovies.php
@@ -136,3 +136,17 @@ function wpmovies_add_key_to_featured_image( $content ) {
 }
 
 add_filter( 'render_block', 'wpmovies_add_key_to_featured_image', 10, 1 );
+
+
+/**
+ * add aria-live region to query block so that the live
+ * updating results are announced to screen readers.
+ */
+function wpmovies_add_aria_live_to_query_block( $content ) {
+	$p = new WP_HTML_Tag_Processor( $content );
+	$p->next_tag( array( 'class' => 'wp-block-query' ) );
+	$p->set_attribute( 'aria-live', 'polite' );
+	return (string) $p->get_updated_html();
+}
+
+add_filter( 'render_block_core/query', 'wpmovies_add_aria_live_to_query_block', 10, 1 );


### PR DESCRIPTION
This fixes an accessibility issue with the SPA search. When you use a screen reader like Voice over and use the search you previously got no indication that the search results were updating. 

Ideally this would also use a directive to get the number of results found. 

I also tried to add some content to the "No Results" block in the query and with the client site navigation this never gets rendered 🤔 